### PR TITLE
Status Fix for Swift 4.2 Filtering Swift Evolution

### DIFF
--- a/proposals/0197-remove-where.md
+++ b/proposals/0197-remove-where.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0197](0197-remove-where.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented** for Swift 4.2
+* Status: **Implemented (Swift 4.2)**
 * Implementation: [apple/swift#11576](https://github.com/apple/swift/pull/11576)
 * Review: [Thread](https://forums.swift.org/t/se-0197-add-in-place-remove-where/8872)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/feec7890d6c193e9260ac9905456f25ef5656acd/proposals/0197-remove-where.md)


### PR DESCRIPTION
This proposal doesn't appear when you filter by Swift 4.2: https://apple.github.io/swift-evolution/#?version=4.2

I believe the status needs to change to "Implemented (Swift 4.2)"